### PR TITLE
fix: delay in test results panel

### DIFF
--- a/keylogger-mvp/extension.js
+++ b/keylogger-mvp/extension.js
@@ -191,18 +191,21 @@ function runTest() {
               }
               console.log("DEBUG 1: failingTestID = ", failingTestID);
             } else {
-              failingTestID = stdout.split("\n");
-              failingTestID.pop();
-              console.log("DEBUG 2: failingTestID = ", failingTestID);
-              current = total - failingTestID.length;
-              if (current == total) {
-                writeState();
-                finishTesting();
-                survey();
+                failingTestID = stdout.split("\n");
+                failingTestID.pop();
+                console.log("DEBUG 2: failingTestID = ", failingTestID);
+                current = total - failingTestID.length;
+                if (current == total) {
+                  writeState();
+                  finishTesting();
+                  survey();
+              }
               }
             }
+            updateStatus();
           }
         );
+        console.log("DEBUG: A Python test was executed.")
       } else if (language.toLowerCase() === "coq") {
         exec(
           `cd ${pathOfPy}; ${pyvers} replacer.py ${uri}`,
@@ -216,7 +219,6 @@ function runTest() {
       }
     });
   }
-  updateStatus();
 }
 
 // This method is called when the extension is deactivated, it is unreliable and most cleanup should be done on "Stop Testing"
@@ -369,6 +371,7 @@ function recordCursorMovements() {
  * @inner
  */
 function updateStatus() {
+  console.log("DEBUG Updating status.")
   rightWindow.webview.html = getWebViewContent(current, total);
 }
 

--- a/keylogger-mvp/extension.js
+++ b/keylogger-mvp/extension.js
@@ -189,11 +189,9 @@ function runTest() {
               for (let i = 0; i < __problem.testCases.length; i++) {
                 failingTestID.push(i);
               }
-              console.log("DEBUG 1: failingTestID = ", failingTestID);
             } else {
                 failingTestID = stdout.split("\n");
                 failingTestID.pop();
-                console.log("DEBUG 2: failingTestID = ", failingTestID);
                 current = total - failingTestID.length;
                 if (current == total) {
                   writeState();
@@ -204,7 +202,6 @@ function runTest() {
             updateStatus();
           }
         );
-        console.log("DEBUG: A Python test was executed.")
       } else if (language.toLowerCase() === "coq") {
         exec(
           `cd ${pathOfPy}; ${pyvers} replacer.py ${uri}`,
@@ -370,7 +367,6 @@ function recordCursorMovements() {
  * @inner
  */
 function updateStatus() {
-  console.log("DEBUG Updating status.")
   rightWindow.webview.html = getWebViewContent(current, total);
 }
 
@@ -466,7 +462,6 @@ function getFailingTestDetails(failingTestID) {
   if (failingTestID.length === 0) {
     return "";
   }
-  console.log("DEBUG 3: failingTestID = ", failingTestID);
   let result = "<h2>Failed Tests:</h2><ul>";
   for (let i = 0; i < failingTestID.length; i++) {
     result += `<li>Input: ${
@@ -478,7 +473,6 @@ function getFailingTestDetails(failingTestID) {
 }
 
 function writeState() {
-  // console.log(events);
   if (!log) return;
   request.post(
     `${_serverURL}/save`,

--- a/keylogger-mvp/extension.js
+++ b/keylogger-mvp/extension.js
@@ -199,9 +199,8 @@ function runTest() {
                   writeState();
                   finishTesting();
                   survey();
+                }
               }
-              }
-            }
             updateStatus();
           }
         );

--- a/keylogger-mvp/pluginConfig.json
+++ b/keylogger-mvp/pluginConfig.json
@@ -1,5 +1,5 @@
 {
     "surveyLink": "https://EnterYourSurveyLinkHere.com",
-    "timerLength": 20000,
+    "timerLength": 2000000,
     "serverURL": "http://virulent.cs.umd.edu:3000"
 }


### PR DESCRIPTION
fix for #9 where there was a delay in the test results panel. Previously, `updateStatus` was called at the end of `runTest` but the `exec` function used to execute tests creates a asynchronous child process. This caused `updateStatus` to be called even before the tests had been executed and before `failingTestID` was updated. The issue has been rectified after the call to `updateStatus` has been moved inside the callback function of `exec`.